### PR TITLE
Fix worng links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@
   ### Authentication
   * [django-rest-passwordreset](https://github.com/anx-ckreuzberger/django-rest-passwordreset): Password reset endpoints that hook into Django Authentication system
   * [djoser](https://github.com/sunscrapers/djoser): REST implementation of Django authentication system
-  * [django-rest-auth](https://github.com/Tivix/django-rest-auth/): A set of REST API endpoints to handle User Registration and Authentication tasks - ( **on pause and is currently unsupported**, [check newer fork](https://github.com/Styria-Digital/django-rest-framework-jwt) )
+  * [django-rest-auth](https://github.com/Tivix/django-rest-auth/): A set of REST API endpoints to handle User Registration and Authentication tasks - ( **on pause and is currently unsupported**, [but there is a newer fork](https://github.com/jazzband/dj-rest-auth) )
   * [django-rest-registration](https://github.com/apragacz/django-rest-registration): User registration and authentication REST API, based on Django REST Framework.
-  * [django-rest-framework-jwt](https://github.com/GetBlimp/django-rest-framework-jwt/): JSON Web Token Authentication support for Django REST Framework - ( **currently unmaintained**, [check newer fork](https://github.com/jazzband/dj-rest-auth) )
+  * [django-rest-framework-jwt](https://github.com/GetBlimp/django-rest-framework-jwt/): JSON Web Token Authentication support for Django REST Framework - ( **currently unmaintained**, [but there is a newer fork](https://github.com/Styria-Digital/django-rest-framework-jwt) )
   * [django-rest-framework-simplejwt](https://github.com/davesque/django-rest-framework-simplejwt): A JSON Web Token authentication plugin for the Django REST Framework
   * [django-rest-framework-social-oauth2](https://github.com/PhilipGarnero/django-rest-framework-social-oauth2): python-social-auth and oauth2 support for django-rest-framework
   * [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit): Django OAuth Toolkit can help you providing out of the box all the endpoints, data and logic needed to add OAuth2 capabilities to your Django projects. Django OAuth Toolkit makes extensive use of the excellent OAuthLib, so that everything is rfc-compliant.


### PR DESCRIPTION
Fix worng links for django-rest-framework-jwt and django-rest-auth newer forks