### PR TITLE
Add django rest swagger deprecated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   * [dry-rest-permissions](https://github.com/dbkaplan/dry-rest-permissions): Rules based permissions for the Django Rest Framework
 
   ### Documentation
-  * [django-rest-swagger](https://github.com/marcgibbons/django-rest-swagger): Swagger Documentation Generator for Django REST Framework (deprecated (for Django 2.2+) )
+  * [django-rest-swagger](https://github.com/marcgibbons/django-rest-swagger): Swagger Documentation Generator for Django REST Framework (this package is deprecated and no longer maintained. It throw error as staticfiles template tag was deprecated in Django 2.2 and is finally removed in Django 3.0. it's recommended to use drf-yasg )
   * [drf-yasg](https://github.com/axnsan12/drf-yasg): Alternative OpenAPI Generator for Django REST Framework with response schema support
 
   ### Routing

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   * [dry-rest-permissions](https://github.com/dbkaplan/dry-rest-permissions): Rules based permissions for the Django Rest Framework
 
   ### Documentation
-  * [django-rest-swagger](https://github.com/marcgibbons/django-rest-swagger): Swagger Documentation Generator for Django REST Framework
+  * [django-rest-swagger](https://github.com/marcgibbons/django-rest-swagger): Swagger Documentation Generator for Django REST Framework (deprecated (for Django 2.2+) )
   * [drf-yasg](https://github.com/axnsan12/drf-yasg): Alternative OpenAPI Generator for Django REST Framework with response schema support
 
   ### Routing


### PR DESCRIPTION
Added django rest swagger deprecated info to resolve issue #16 . 

The problem is that staticfiles template tag was deprecated in Django 2.2 and is finally removed in Django 3.0
The django-rest-swagger package itself is deprecated and is no longer maintained.
Their GitHub repo also recommends drf-yasg
https://stackoverflow.com/questions/59230539/django-rest-swagger-staticfiles-is-not-a-registered-tag-library-must-be-one 