### PR TITLE
add django-rest-tsg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
   * [drf-extensions](https://github.com/chibisov/drf-extensions): DRF-extensions is a collection of custom extensions for Django REST Framework
   * [drf-generators](https://github.com/Brobin/drf-generators): Generate Views, Serializers, and Urls for your Django Rest Framework application.
   * [django-restql](https://github.com/yezyilomo/django-restql): Turn your API made with Django REST Framework(DRF) into a GraphQL like API. 
+  * [django-rest-tsg](https://github.com/jinkanhq/django-rest-tsg): A TypeScript code generator for DRF serializers, enums and dataclasses.
 
   ## Tutorials
   * [The Complete Guide to Django REST Framework and Vue JS](https://www.udemy.com/course/the-complete-guide-to-django-rest-framework-and-vue-js/?referralCode=A2FA0F6C1C4BE66A3B3E)


### PR DESCRIPTION
Django REST Typescript Generator

A TypeScript code generator for Django Rest Framework, which saved your hand-working and guaranteed consistency between Python codes and modern frontend codes written in TypeScript.