### PR TITLE
Add drf-simple-api-errors to Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
   ### Serialization
   * [django-rest-framework-recursive](https://github.com/heywbj/django-rest-framework-recursive/): Recursive Serialization for Django REST framework
   * [drf-extra-fields](https://github.com/Hipo/drf-extra-fields/): Extra fields for Django REST framework.
+  * [drf-simple-api-errors](https://github.com/gripep/drf-simple-api-errors): Consistent, predictable API error responses inspired by RFC 7807, with drf-spectacular integration for OpenAPI schemas.
   * [drf-errors](https://github.com/null-none/drf-errors/): Extension for Django REST framework error display.
   * [drf-flex-fields](https://github.com/rsinger86/drf-flex-fields): Dynamically set fields and expand nested resources in Django REST Framework serializers. 
   * [drf-writable-nested](https://github.com/beda-software/drf-writable-nested): Writable nested model serializer for Django REST Framework


### PR DESCRIPTION
I'd like to add [drf-simple-api-errors](https://github.com/gripep/drf-simple-api-errors), a small library that turns DRF/Django exceptions into consistent, RFC 7807-inspired JSON error responses with a predictable format.

A bit of context on placement: the list already has `drf-errors` for a similar need, but it hasn't had an update since 2022. `drf-simple-api-errors` is actively maintained, tested against Python 3.9–3.13 and current DRF, used in production, and ships an optional `drf-spectacular` integration so the error shapes show up in your OpenAPI schema (handy for modern stacks).

Glad to tweak the wording, placement, or description to match the list's conventions.

Thanks for taking a look!